### PR TITLE
Update all Brew Formulas to have SHA256 Hashes

### DIFF
--- a/files/brews/autoconf213.rb
+++ b/files/brews/autoconf213.rb
@@ -4,7 +4,7 @@ class Autoconf213 < Formula
   homepage 'http://www.gnu.org/software/autoconf/'
   url 'http://ftpmirror.gnu.org/autoconf/autoconf-2.13.tar.gz'
   mirror 'http://ftp.gnu.org/gnu/autoconf/autoconf-2.13.tar.gz'
-  sha1 'e4826c8bd85325067818f19b2b2ad2b625da66fc'
+  sha256 'f0611136bee505811e9ca11ca7ac188ef5323a8e2ef19cffd3edb3cf08fd791e'
 
   version '2.13-boxen1'
 

--- a/files/brews/bison26.rb
+++ b/files/brews/bison26.rb
@@ -4,7 +4,7 @@ class Bisonphp26 < Formula
   homepage 'http://www.gnu.org/software/bison/'
   url 'http://ftpmirror.gnu.org/bison/bison-2.6.4.tar.gz'
   mirror 'http://ftp.gnu.org/gnu/bison/bison-2.6.4.tar.gz'
-  sha1 '38adec0d7d0f556ec52e21ccbb87edd78327dd9b'
+  sha256 'de2d15dfdcfc24405464cb95acc9d5ef31fb2e5be4aca6a530ec59bb57c30e5d'
 
   version '2.6.4-boxen1'
 

--- a/files/brews/freetds.rb
+++ b/files/brews/freetds.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Freetds < Formula
   homepage 'http://www.freetds.org/'
   url 'http://mirrors.ibiblio.org/freetds/stable/freetds-0.91.tar.gz'
-  sha1 '3ab06c8e208e82197dc25d09ae353d9f3be7db52'
+  sha256 '6a8148bd803aebceac6862b0dead1c5d9659f7e1038993abfe0ce8febb322465'
 
   depends_on "pkg-config" => :build
   depends_on "unixodbc" => :optional

--- a/files/brews/freetype.rb
+++ b/files/brews/freetype.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Freetypephp < Formula
   homepage 'http://www.freetype.org'
   url 'http://downloads.sf.net/project/freetype/freetype2/2.4.11/freetype-2.4.11.tar.gz'
-  sha1 'a8373512281f74a53713904050e0d71c026bf5cf'
+  sha256 '29a70e55863e4b697f6d9f3ddc405a88b83a317e3c8fd9c09dc4e4c8b5f9ec3e'
 
   keg_only "Sandboxed for PHP installations"
 

--- a/files/brews/zlib.rb
+++ b/files/brews/zlib.rb
@@ -1,19 +1,62 @@
-require 'formula'
-
 class Zlibphp < Formula
-  homepage 'http://www.zlib.net/'
-  url 'http://zlib.net/zlib-1.2.8.tar.gz'
-  sha1 'a4d316c404ff54ca545ea71a27af7dbc29817088'
+  desc "General-purpose lossless data-compression library"
+  homepage "http://www.zlib.net/"
+  url "http://zlib.net/zlib-1.2.8.tar.gz"
+  mirror "https://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz"
+  sha256 "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d"
 
-  keg_only :provided_by_osx
+  bottle do
+    cellar :any
+    revision 1
+    sha256 "2971abbd45572722af5043a74ecf8a5bfd06adc9834ec90e4126a34c6ce982a1" => :yosemite
+    sha256 "adc394a9e296003bc2bc88451c649aec019496cb6ed3d6673005fcd818ae44a5" => :mavericks
+    sha256 "6ece1cb4b656f0f7ef1feab95ef6eb183e2f9ee2448c1e034de1a97d7f9da249" => :mountain_lion
+  end
 
   version '1.2.8-boxen1'
+  keg_only :provided_by_osx
 
   option :universal
+
+  # configure script fails to detect the right compiler when "cc" is
+  # clang, not gcc. zlib mantainers have been notified of the issue.
+  # See: https://github.com/Homebrew/homebrew-dupes/pull/228
+  patch :DATA
+
+  # http://zlib.net/zlib_how.html
+  resource "test_artifact" do
+    url "http://zlib.net/zpipe.c"
+    version "20051211"
+    sha256 "68140a82582ede938159630bca0fb13a93b4bf1cb2e85b08943c26242cf8f3a6"
+  end
 
   def install
     ENV.universal_binary if build.universal?
     system "./configure", "--prefix=#{prefix}"
-    system "make install"
+    system "make", "install"
+  end
+
+  test do
+    testpath.install resource("test_artifact")
+    system ENV.cc, "zpipe.c", "-I#{include}", "-L#{lib}", "-lz", "-o", "zpipe"
+
+    touch "foo.txt"
+    output = "./zpipe < foo.txt > foo.txt.z"
+    system output
+    assert File.exist?("foo.txt.z")
   end
 end
+
+__END__
+diff --git a/configure b/configure
+index b77a8a8..54f33f7 100755
+--- a/configure
++++ b/configure
+@@ -159,6 +159,7 @@ case "$cc" in
+ esac
+ case `$cc -v 2>&1` in
+   *gcc*) gcc=1 ;;
++  *clang*) gcc=1 ;;
+ esac
+ 
+ show $cc -c $test.c


### PR DESCRIPTION
Brew is depricating sha1 hashes, so this updates all the hashes
in these brews to SHA256. I manually downloaded these brew files
and confirmed their SHA1 mathces what we have, then I got a SHA256
for the package and replaced the SHA1.
The only exception is Zlib. Which the downloaded SHA1 didbn't match
what the Formula says. But I found a newer Formula, for the same version,
that has a matching SHA256.
