### PR TITLE
Remove FreeType Mountain Lion Bottle

### DIFF
--- a/files/brews/freetype.rb
+++ b/files/brews/freetype.rb
@@ -9,11 +9,6 @@ class Freetypephp < Formula
 
   option :universal
 
-  bottle do
-    # Included with X11 so no bottle needed before Mountain Lion.
-    sha1 '7dc4747810e51beb99fd36c8f5baade6e65d19b7' => :mountain_lion
-  end
-
   def install
     ENV.universal_binary if build.universal?
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
/domain @while1malloc0

Remove freetype php bottle, since it only have sha1 hashes and we are deprecating this puppet module soon anyways.

It was causing a SHA1 error since it only specifies a SHA1 hash